### PR TITLE
Fix duplicate, unclickable row when re-dropping the same track

### DIFF
--- a/crates/stemd-server/src/drops.rs
+++ b/crates/stemd-server/src/drops.rs
@@ -114,6 +114,19 @@ pub struct Drops {
     recent: Mutex<Vec<Arc<Dropped>>>,
 }
 
+/// Put a fresh drop at the top of the list, replacing any row already there
+/// for the same source rather than duplicating it.
+///
+/// Dropping a track that is still in the list is a re-run, not a new entry:
+/// the old row is what the user just dragged again, so it moves to the top
+/// with the new run's state instead of sitting alongside a second copy of
+/// itself.
+fn remember(recent: &mut Vec<Arc<Dropped>>, dropped: Arc<Dropped>) {
+    recent.retain(|other| other.source != dropped.source);
+    recent.insert(0, dropped);
+    recent.truncate(REMEMBERED);
+}
+
 impl Drops {
     /// Take a file and start working on it. Returns the entry the window draws.
     ///
@@ -127,11 +140,7 @@ impl Drops {
             state: Mutex::new(State::Reading),
         });
 
-        {
-            let mut recent = self.recent.lock();
-            recent.insert(0, Arc::clone(&dropped));
-            recent.truncate(REMEMBERED);
-        }
+        remember(&mut self.recent.lock(), Arc::clone(&dropped));
 
         let state = Arc::clone(state);
         let started = Arc::clone(&dropped);
@@ -498,5 +507,32 @@ mod tests {
     #[test]
     fn a_file_with_no_parent_still_gets_a_folder() {
         assert_eq!(output_dir(Path::new("track.wav")), Path::new("track-stems"));
+    }
+
+    /// Re-dropping a track already in the list moves it to the top instead of
+    /// adding a second row for it; this is also what keeps two rows from ever
+    /// sharing the window's per-row egui id, which is derived from the source.
+    #[test]
+    fn re_dropping_a_track_replaces_its_row_instead_of_duplicating() {
+        let mut recent = Vec::new();
+        let other = finished_drop(Path::new("/b"));
+        remember(&mut recent, Arc::clone(&other));
+        let first_run = finished_drop(Path::new("/a"));
+        remember(&mut recent, Arc::clone(&first_run));
+        assert_eq!(recent.len(), 2);
+
+        let second_run = finished_drop(Path::new("/a"));
+        remember(&mut recent, Arc::clone(&second_run));
+
+        assert_eq!(
+            recent.len(),
+            2,
+            "dropping the same track again duplicated its row"
+        );
+        assert!(
+            Arc::ptr_eq(&recent[0], &second_run),
+            "the re-run did not move to the top"
+        );
+        assert!(Arc::ptr_eq(&recent[1], &other), "an unrelated row moved");
     }
 }

--- a/crates/stemd-server/src/ui/recents.rs
+++ b/crates/stemd-server/src/ui/recents.rs
@@ -92,7 +92,12 @@ fn row(
     // shifts whenever the list above changes shape, and an id that changes
     // between frames cannot correlate a press with its release, which is
     // exactly a row that highlights on hover and does nothing when clicked.
-    let id = ui.id().with(("recent", &item.title));
+    //
+    // Keyed on the source path rather than the title: two different files can
+    // share a title (different folders, same name), and `title` alone would
+    // hand both rows the same id, colliding in exactly the way this comment
+    // warns about.
+    let id = ui.id().with(("recent", &item.source));
     let response = ui.interact(rect, id.with("row"), egui::Sense::click());
 
     // Registered after the row and overlapping it, so egui hands it the pointer


### PR DESCRIPTION
Fixes nsaintot/stemd#2

## The bug

If you drop the same track on the window twice (or drop it again after it already finished separating), the "Separated" list ended up with two rows for it instead of one. The newer of the two rows was broken: hovering and clicking did nothing on it. To get any hover/click feedback on that track, you had to move the mouse onto the *older* duplicate row further down the list instead.

## Why it happened

Two separate things combined to cause this:

1. **Nothing de-duplicated the list.** Every time a file was dropped, the window just inserted a brand-new row at the top of the "recent drops" list, with no check for whether that same file was already sitting somewhere in the list. So re-running a track always added a second row rather than updating the one already there.

2. **Rows were sharing an identity behind the scenes.** Each row's click/hover handling needs a stable ID so the UI toolkit (egui) can tell "this row was pressed" from "that row was pressed." That ID was built from the track's display name (the file's title). But two rows for the same file obviously have the same title, so both rows ended up using the *exact same ID*. egui only routes input correctly when every interactive element has a unique ID, so with two rows sharing one ID, input got misattributed — the newer row looked normal but silently couldn't be clicked, while the older row (usually hidden further down the list) picked up the intended interaction instead.

## The fix

- When a track is dropped, the window now first removes any existing row for that same source file before adding the new one, then puts the new row at the top. So re-dropping a track now moves it to the top of the list and refreshes its status, instead of piling up a duplicate.
- Row IDs are now built from the file's full path instead of its display name. This is a more accurate identity anyway (two different files in different folders can share the same name), and it means two rows can never again collide on the same ID, so this class of bug can't resurface even in that edge case.

## Tests added

Added a test that simulates dropping the same file twice: it drops file A, then drops an unrelated file B, then drops file A again, and checks that:
- the list still has exactly two rows (no duplicate was created),
- the re-dropped file A is now at the top of the list,
- the unrelated file B's row wasn't disturbed.

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)